### PR TITLE
Force json data type since that is what we're expecting

### DIFF
--- a/i18n.js
+++ b/i18n.js
@@ -36,6 +36,7 @@ I18n.prototype = {
         $.ajax({
             url: this.directory + "/" + this.locale + this.extension,
             async: false,
+            dataType: 'json',
             success: function(data){
                 localeFile = data;
             }


### PR DESCRIPTION
If the server does not set the right MIME type, the data might be
interpretted as a string and it does not become a JavaScript object; as
a result, all translations fail.
